### PR TITLE
added functionality to update sample data with form

### DIFF
--- a/src/api/facts.js
+++ b/src/api/facts.js
@@ -12,15 +12,16 @@ const postFact = async (obj, val) => {
   return response;
 };
 
-const updateFact = async (firebaseKey, val) => {
-  const patch = await fetch(`${dbUrl}/response${val}/${firebaseKey}.json`, {
+const updateFact = async (payload, val) => {
+  const patch = await fetch(`${dbUrl}/response${val}/${payload.firebaseKey}.json`, {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({
-      firebaseKey, // this adds the firebase key to the object in the database. it is shorthand for firebaseKey: firebaseKey.  In JavaScript, you can use shorthand notation to create key-value pairs where the key is the same as the variable name.
-    }),
+    // body: JSON.stringify({
+    //   firebaseKey, // this adds the firebase key to the object in the database. it is shorthand for firebaseKey: firebaseKey.  In JavaScript, you can use shorthand notation to create key-value pairs where the key is the same as the variable name.
+    // }),
+    body: JSON.stringify(payload),
   });
   const response = patch.json();
   return response;

--- a/src/app/form/page.js
+++ b/src/app/form/page.js
@@ -1,78 +1,21 @@
-'use client';
+import React from 'react';
+import Form from '@/components/form';
 
-import React, { useState } from 'react';
-import { useAuth } from '@/utils/context/authContext';
-import { postFact, updateFact } from '@/api/facts';
-
-// our endpoint/api call is expecting this object structure
-const initialState = {
-  text: '',
-  name: '',
-};
+// const sampleData = {
+//   "firebaseKey": "-OFsMVQdVLfZGFIVJq37",
+//         "name": "a",
+//         "text": "grass is green",
+//         "userID": "hSjPvyVllcQgN5Hm35xVEuUn1UJ3",
+// }
 
 export default function FormPage() {
-  const { user } = useAuth();
-  const [factDetails, setFactDetails] = useState(initialState);
-
-  // the event is 'onChange'
-  // whenever we are binding our input values to our state values, we want to make sure the names are the same. that's why we're using the 'name' attribute on the input.
-  const handleInputUpdate = (e) => {
-    console.log(e);
-    const { name, value } = e.target;
-
-    // whenever we handle the input, the state is updating, so we call setFactDetails
-    // we are just modifying the state item. we use prevState with spread operator to make sure we don't overwrite everything else in the object.
-    setFactDetails((prevState) => ({
-      // it's going to spread the text and the name (whatever is in there) and then it's going to overwrite whatever name or key matches whatever is inside that object.
-      ...prevState,
-      // name is in brackets because we're doing it dynamically. we're not looking for the key 'name', we're looking for the key that is the value of the name variable.
-      // for Fact, it is 'text' and for Your Name, it is 'name'
-      // Brackets for Dynamic Property Names: The brackets allow you to use the value of a variable as the property name in an object.
-      // brackets are needed for dynamic keys, but not for the dynamic values ( in key: value pairs)
-      [name]: value,
-    }));
-  };
-
-  const resetForm = () => {
-    setFactDetails(initialState);
-  };
-
-  // for handleSubmit, we want to 1.) grab the values from the current state, and 2.) send them to the database via api call to firebase, to create.
-  const handleSubmit = async (e) => {
-    // prevent page from reloading
-    e.preventDefault();
-
-    // postFact gives us access to the firebasekey, which we need to update the fact in the database. it accepts an object and a value (yes or no) as args
-    const response = await postFact(
-      {
-        // spread the fact details that we set in handleInputUpdate
-        ...factDetails,
-        // add the user id to the object
-        userID: user.uid,
-      },
-      'Yes',
-    ); // using yes because since they are submitting the fact, we assume yes they knew it
-
-    // updateFact accepts the firebase key and a value (yes or no) as args
-    // response.name is the firebase key. it is from response from the postFact api call above. '.name' giving the fireabse key is specific (built in) to firebase.
-    await updateFact(response.name, 'Yes'); // using yes because since they are submitting the fact, we assume yes they knew it
-
-    resetForm();
-  };
-
   return (
-    <form className="container" onSubmit={handleSubmit}>
-      <div>
-        <label htmlFor="text">Fact</label>
-        <input onChange={handleInputUpdate} type="text" name="text" id="text" className="form-control" value={factDetails.text} required />
-      </div>
-      <div>
-        <label htmlFor="name">Your Name</label>
-        <input onChange={handleInputUpdate} type="text" name="name" id="name" className="form-control" value={factDetails.name} required />
-      </div>
-      <button className="btn btn-success" type="submit">
-        Submit
-      </button>
-    </form>
+    <div className="container">
+      <h2> CREATE A FACT</h2>
+      <Form />
+
+      {/* <h2> UPDATE </h2>
+      <Form obj={sampleData} /> */}
+    </div>
   );
 }

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -49,7 +49,8 @@ function Home() {
     // the api call returns a response, and that response is going to contain the firebase key.
     // we want to duplicate the key into the object
     const response = await postFact(obj, val); // this posts the fact to the database and then it is seen in the responseYes or responseNo pages (in navbar). we also use it below in update to access the firebase key.
-    await updateFact(response.name, val); // respose.name is the firebase key which updateFact accepts as an argument.
+    await updateFact({ firebaseKey: response.name }, val); // respose.name is the firebase key which updateFact accepts as an argument.
+    // we changed it to firebaseKey: response.name because we changed the format of the api call in facts.js to accept paylaod as an argument. payload is an object that contains the firebase key and the value.
     // this patches the firebase key into the object in the database. see the api file for more info.
 
     fetchFact();

--- a/src/components/form.js
+++ b/src/components/form.js
@@ -1,0 +1,96 @@
+'use client';
+
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useAuth } from '@/utils/context/authContext';
+import { postFact, updateFact } from '@/api/facts';
+
+// our endpoint/api call is expecting this object structure
+const initialState = {
+  text: '',
+  name: '',
+};
+
+export default function Form({ obj = initialState }) {
+  const { user } = useAuth();
+  const [factDetails, setFactDetails] = useState(obj);
+
+  // the event is 'onChange'
+  // whenever we are binding our input values to our state values, we want to make sure the names are the same. that's why we're using the 'name' attribute on the input.
+  const handleInputUpdate = (e) => {
+    console.log(e);
+    const { name, value } = e.target;
+
+    // whenever we handle the input, the state is updating, so we call setFactDetails
+    // we are just modifying the state item. we use prevState with spread operator to make sure we don't overwrite everything else in the object.
+    setFactDetails((prevState) => ({
+      // it's going to spread the text and the name (whatever is in there) and then it's going to overwrite whatever name or key matches whatever is inside that object.
+      ...prevState,
+      // name is in brackets because we're doing it dynamically. we're not looking for the key 'name', we're looking for the key that is the value of the name variable.
+      // for Fact, it is 'text' and for Your Name, it is 'name'
+      // Brackets for Dynamic Property Names: The brackets allow you to use the value of a variable as the property name in an object.
+      // brackets are needed for dynamic keys, but not for the dynamic values ( in key: value pairs)
+      [name]: value,
+    }));
+  };
+
+  const resetForm = () => {
+    setFactDetails(initialState);
+  };
+
+  // for handleSubmit, we want to 1.) grab the values from the current state, and 2.) send them to the database via api call to firebase, to create.
+  const handleSubmit = async (e) => {
+    // prevent page from reloading
+    e.preventDefault();
+
+    if (factDetails.firebaseKey) {
+      // if object has a firebase key, it means it is an existing fact that we are updating. really just convenient difference that we can utilize as our conditional
+
+      // UPDATE FACT:
+      await updateFact(factDetails, 'Yes'); // TODO: can always update the form with a select yes or no to have users select. for now it's just going to send it to yes.
+    } else {
+      // if object does not have a firebase key, it means it is a new fact that we are creating
+
+      // CREATE FACT:
+
+      // postFact gives us access to the firebasekey, which we need to update the fact in the database. it accepts an object and a value (yes or no) as args
+      const response = await postFact(
+        {
+          // spread the fact details that we set in handleInputUpdate
+          ...factDetails,
+          // add the user id to the object
+          userID: user.uid,
+        },
+        'Yes',
+      ); // using yes because since they are submitting the fact, we assume yes they knew it
+
+      // updateFact accepts the firebase key and a value (yes or no) as args
+      // response.name is the firebase key. it is from response from the postFact api call above. '.name' giving the fireabse key is specific (built in) to firebase.
+      await updateFact({ firebaseKey: response.name }, 'Yes'); // using yes because since they are submitting the fact, we assume yes they knew it
+      resetForm();
+    }
+  };
+
+  return (
+    <form className="container" onSubmit={handleSubmit}>
+      <div>
+        <label htmlFor="text">Fact</label>
+        <input onChange={handleInputUpdate} type="text" name="text" id="text" className="form-control" value={factDetails.text} required />
+      </div>
+      <div>
+        <label htmlFor="name">Your Name</label>
+        <input onChange={handleInputUpdate} type="text" name="name" id="name" className="form-control" value={factDetails.name} required />
+      </div>
+      <button className="btn btn-success" type="submit">
+        Submit
+      </button>
+    </form>
+  );
+}
+
+Form.propTypes = {
+  obj: PropTypes.shape({
+    text: PropTypes.string,
+    name: PropTypes.string,
+  }).isRequired,
+};


### PR DESCRIPTION
- moved content from form  page from create to a new file in components called form.js.
- used the form component from form.js as a component in the form page.js. inserted it twice: create, update. each form has its’ own state.
- in the update form, pass an object in so that when it loads, if there is a value in this obj, it will put it inside of the form
    - grab an obj from postman. const sample data and paste that obj. pass that obj into Form component for update (on page.js).
    - nothing happens yet bc we need to make some modifications to the form component form (form.js in components)
        - give it an obj prop and default value of initialState (text and name) need to give a default value bc if it’s not passed an obj (like in create), we don’t want our form to break
        - so then what happens is, if i pass an obj to this component, then it will set the value of fact details to whatever that object was. if i don’t, then it will set it to initial state.
        - yayyyyy, now the update form inputs have the values of the sample data!
- but on submit still creates a new fact. how can we differentiate the two?
    - **well. the obj for create does not yet have a firebase key, but the object for update does. so in handleSubmit, we can do a conditional, if the object has a firebase key… update. if it doesn’t, create.**
    - with that….. we have to fix some stuff:
    - we need to modify existing functions that use updateFact. in page.js in app, we change it to label it as firebase key that it accepts:
        
        
        ```
            await updateFact({firebaseKey: response.name}, val); // respose.name is the firebase key which updateFact accepts as an argument.
            // this patches the firebase key into the object in the database. see the api file for more info.
        
            fetchFact();
            return obj;
        ```
        
    - and we need to modify updateFact api call in facts.js to accept payload instead of firebaseKey as an argument. so that it works when there isn’t a firebase key too? or noooo… previosuly we only used updateFact to patch a firebasekey on. but now we want to use it to actually update the other fields. so it need to accept payload (which still is used to access firebase key, since we still need ti in the fetch URL) and that is what is updated in ‘body:’ of the api call. updating payload still serves the purpose of patchingn the firebasekey onto the object because we made the payload (in app page.js):{firebaseKey: [[response.name](http://response.name/)](http://response.name/)}.
        - we also updated in the form.js when updateFact is called:     await updateFact(firebaseKey: [[response.name](http://response.name/)](http://response.name/), 'Yes');…. to update with a ‘payload’ and not just a firebasekey
        
        ok the conditional works. update form works. but it’s only for the sample data. somehow we need to attach that to a button on existing facts.